### PR TITLE
Fix blog post about Git empty directories

### DIFF
--- a/website/content/posts/2019-03-11_empty-directories-in-git-repository/index.md
+++ b/website/content/posts/2019-03-11_empty-directories-in-git-repository/index.md
@@ -5,17 +5,17 @@ layout: post
 slug: empty-directories-in-git-repository
 tags: ["git"]
 description: >
-    Creating empty directories in git repository is a daily business task and everybody did it a few times.
-    The example from real life may be a directory for cache, logs, build artifacts etc.
-    There are two different ways how to get the result: creating a `.gitignore` with a specific content or creating
-    an empty file, usually `.gitkeep` in the directory. I will explain why the latter approach is better.
+    Creating empty directories in a Git repository is a daily business task and everybody has done it a few times.
+    Examples from real life may be directories for cache, logs, build artifacts, etc.
+    There are two different ways to achieve this: creating a `.gitignore` with specific content or creating
+    an empty file, usually `.gitkeep`, in the directory. I will explain why the latter approach is better.
 
 ---
 
-Creating empty directories in the Git repository is a daily business task, and everybody did it a few times.
-The example from real life may be a directory for cache, logs, build artifacts, etc.
-There are two different ways how to get the result: creating a `.gitignore` with specific content or creating
-an empty file, usually `.gitkeep` in the directory. I will explain why the latter approach is better.
+Creating empty directories in a Git repository is a daily business task, and everybody has done it a few times.
+Examples from real life may be directories for cache, logs, build artifacts, etc.
+There are two different ways to achieve this: creating a `.gitignore` with specific content or creating
+an empty file, usually `.gitkeep`, in the directory. I will explain why the latter approach is better.
 
 The first approach is to create a `.gitignore` file with the following content:
 
@@ -24,16 +24,16 @@ The first approach is to create a `.gitignore` file with the following content:
 !.gitignore
 ```
 
-According to the [documentation](https://git-scm.com/docs/gitignore) Git will process `.gitignore` files moving from the root level to nested directories and overriding rules that coincide.
+According to the [documentation](https://git-scm.com/docs/gitignore), Git will process `.gitignore` files moving from the root level to nested directories and overriding rules that coincide.
 In other words, the lowest `.gitignore` file in the directory will always win.
 
 The downside of having a few `.gitignore` files in the project is that it gets harder to fetch the full list of empty directories.
 This may be especially a problem for the people who just started working on the project and don't know the codebase well enough.
 
-I find an approach with creating a `.gitkeep` to be more useful.
+I find the approach of creating a `.gitkeep` file to be more useful.
 This approach allows having exactly one `.gitignore` file in the project, with as many empty directories as needed.
 
-There is one additional line that excludes `.gitignore` everywhere:
+There is one additional line that includes `.gitkeep` files everywhere:
 
 ```
 # .gitignore
@@ -56,4 +56,4 @@ Then, add the directory in question to the `.gitignore`:
 ```
 
 Pay attention to the `*` at the end – this will affect only files inside the directory, but not the directory itself.
-The trick is that `*` does not cover so-called dotfiles and ignores `.gitkeep`.
+The trick is that `*` does not cover so-called dotfiles, so it ignores `.gitkeep`.


### PR DESCRIPTION
**Changes**

- Capitalize 'Git' and add article for proper grammar
- Change 'did it' to 'has done it' for correct tense
- Fix 'ways how to' to 'ways to'
- Correct misleading comment about .gitkeep inclusion
- Add missing comma and improve sentence flow